### PR TITLE
Let's be able to align the caption element also to the bottom.

### DIFF
--- a/js/jssor.js
+++ b/js/jssor.js
@@ -1959,6 +1959,7 @@ var $Jssor$ = window.$Jssor$ = new function () {
     _This.$CssOverflow = CssProxy("overflow");
 
     _This.$CssTop = CssProxy("top", 2);
+    _This.$CssBottom = CssProxy("bottom", 2);
     _This.$CssLeft = CssProxy("left", 2);
     _This.$CssWidth = CssProxy("width", 2);
     _This.$CssHeight = CssProxy("height", 2);

--- a/js/jssor.slider.js
+++ b/js/jssor.slider.js
@@ -3926,14 +3926,15 @@ var $JssorCaptionSlider$ = window.$JssorCaptionSlider$ = function (container, ca
             $JssorDebug$.$Execute(function () {
                 if (captionItem.length) {
                     var top = $Jssor$.$CssTop(captionItem.$Elmt);
+                    var bottom = $Jssor$.$CssBottom(captionItem.$Elmt);
                     var left = $Jssor$.$CssLeft(captionItem.$Elmt);
                     var width = $Jssor$.$CssWidth(captionItem.$Elmt);
                     var height = $Jssor$.$CssHeight(captionItem.$Elmt);
 
                     var error = null;
 
-                    if (isNaN(top))
-                        error = "Style 'top' for caption not specified. Please always specify caption like 'position: absolute; top: ...px; left: ...px; width: ...px; height: ...px;'.";
+                    if (isNaN(top) && isNaN(bottom))
+                        error = "Style 'top' or 'bottom' for caption not specified. Please always specify caption like 'position: absolute; top: ...px; left: ...px; width: ...px; height: ...px;'.";
                     else if (isNaN(left))
                         error = "Style 'left' not specified. Please always specify caption like 'position: absolute; top: ...px; left: ...px; width: ...px; height: ...px;'.";
                     else if (isNaN(width))


### PR DESCRIPTION
I have a multiline caption, that I want to align to the bottom of the slider: in this case I could use the `top` css property and craft the alignment of the caption, but due to its multiline nature will grow down, and go offslide.

With this simple patch I can keep aligning captions to top as usual, but I can also decide to align the caption to bottom, specifying the `bottom` property in css.