### PR TITLE
Issue 153 - bower-friendly version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jssor-slider",
   "description": "Responsive jQuery Image Slider/Slideshow/Carousel/Gallery/Banner",
-  "version": "19.0",
+  "version": "19.0.1",
   "keywords": [
     "jquery",
     "javascript",


### PR DESCRIPTION
bower requires a semver-compatible version number, e.g. x,y.z.  Currently, the version 19.0 that's there is causing Issue #153.  This is a simple change to allow bower to more reliably fetch and cache jssor.